### PR TITLE
Compile and use SDK 32 build tools

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         }
     }
 
-    compileSdk = 31
-    buildToolsVersion = "31.0.0"
+    compileSdk = 32
+    buildToolsVersion = "32.0.0"
 
     defaultConfig {
         applicationId = "org.grapheneos.apps.client"


### PR DESCRIPTION
We won't target it yet until GrapheneOS has ported to Android 12L.

Signed-off-by: June <june@eridan.me>