### PR TITLE
Target SDK 12L/12.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         applicationId = "app.grapheneos.apps"
         minSdk = 31
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 4
         versionName = versionCode.toString()
     }


### PR DESCRIPTION
GrapheneOS is now on 12.1

Signed-off-by: June <june@eridan.me>