### PR TITLE
Correctly fetch for app version and updated version on new package name of PdfViewer when it's a system app

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -121,6 +121,7 @@ class App : Application() {
     private val confirmationAwaitedPackages = mutableMapOf<String, List<File>>()
 
     private val packagesInfo: MutableMap<String, PackageInfo> = mutableMapOf()
+    private val samePackagesMap: MutableMap<String, String> = mutableMapOf()
     private val packagesMutableLiveData = MutableLiveData<Map<String, PackageInfo>>()
     val packageLiveData: LiveData<Map<String, PackageInfo>> = packagesMutableLiveData
     private val updatableAppsCount: MutableLiveData<Int> = MutableLiveData()
@@ -274,6 +275,13 @@ class App : Application() {
                         .getPackageChannel(this@App, pkgName)
                     val channelVariant = value.variants[channelPref]
                         ?: value.variants[App.getString(R.string.channel_default)]!!
+                    val oldPkgName = channelVariant.originalPkgName
+                    val shouldMapOnSamePackages = !samePackagesMap.containsKey(oldPkgName)
+                            && !samePackagesMap.containsKey(pkgName)
+                    if (oldPkgName != null && shouldMapOnSamePackages) {
+                        samePackagesMap[oldPkgName] = pkgName
+                        samePackagesMap[pkgName] = oldPkgName
+                    }
                     val installStatus = getInstalledStatus(
                         pkgName,
                         channelVariant.versionCode.toLong()

--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -150,7 +150,14 @@ class App : Application() {
         override fun onReceive(context: Context?, intent: Intent?) {
 
             val action = intent?.action ?: return
-            val pkgName = intent.data?.schemeSpecificPart ?: return
+            val oldPkgName = intent.data?.schemeSpecificPart ?: return
+            val newPkgName = samePackagesMap[oldPkgName] ?: oldPkgName
+            val pkgName =
+                when {
+                    oldPkgName == newPkgName -> oldPkgName
+                    isSystemApp(newPkgName, oldPkgName) -> newPkgName
+                    else -> oldPkgName
+                }
 
             val info = packagesInfo[pkgName]
             if (!packagesInfo.containsKey(pkgName) || info == null) {

--- a/app/src/main/java/org/grapheneos/apps/client/item/PackageVariant.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/item/PackageVariant.kt
@@ -6,5 +6,6 @@ data class PackageVariant(
     val type: String,
     val packagesInfo: Map<String, String>, //package and hash
     val versionCode: Int,
-    val dependencies: List<String> = listOf()
+    val dependencies: List<String> = listOf(),
+    val originalPkgName: String? = null
 )

--- a/app/src/main/java/org/grapheneos/apps/client/utils/network/MetaDataHelper.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/network/MetaDataHelper.kt
@@ -179,6 +179,11 @@ class MetaDataHelper constructor(context: Context) {
                 for (itemIndex in 0 until channelItemsJson.length()) {
                     val channelItemJson = channelItemsJson.getJSONObject(itemIndex)
 
+                    val originalPackage = try {
+                        channelItemJson.getString("originalPackage")
+                    } catch (e: JSONException) {
+                        null
+                    }
                     val packages = channelItemJson.getJSONArray("packages")
                     val hashes = channelItemJson.getJSONArray("hashes")
                     val appName = channelItemJson.getString("label")
@@ -206,7 +211,8 @@ class MetaDataHelper constructor(context: Context) {
                             channelName,
                             packageInfoMap,
                             versionCode,
-                            dependencies
+                            dependencies,
+                            originalPackage,
                         )
                     }
                 }


### PR DESCRIPTION
Currently, it is not included in metadata whether an app uses original-package, thus hardwire the special case. 

Have the old package name as fallback to check for versionCode, and if the old package name has been updated and is a system app, update the install status of the newer package name.