### PR TITLE
Wait until device is idle before running update job

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/utils/sharedPsfsMgr/JobPsfsMgr.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/sharedPsfsMgr/JobPsfsMgr.kt
@@ -91,6 +91,7 @@ class JobPsfsMgr(val context: Context) {
         ).setRequiredNetworkType(jobNetworkType())
             .setPersisted(true)
             .setPeriodic(jobRepeatIntervalMillis())
+            .setRequiresDeviceIdle(true)
             .build()
 
         jobScheduler.schedule(jobInfo)


### PR DESCRIPTION
If a user is actively using the device, we don't want Apps to update
apps currently in use because the OS will kill them. This problem
expands to apps outside of those in the repository because some that
depend on Play Services will barf if Play Services is killed while
they're running.

The [API description](https://developer.android.com/reference/android/app/job/JobInfo.Builder#setRequiresDeviceIdle(boolean)) for setRequiresDeviceIdle suggests the device is
considered "idle" when the user isn't actively interacting with it. If
this is the case, Apps could still update apps while the the device is
being "used" (say, a music player is running in the background), but
even so this change would reduce the frequency of apps being killed when
the user doesn't expect them to be.