### PR TITLE
Remove extraneous @Throws annotation

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/utils/network/ApkDownloadHelper.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/network/ApkDownloadHelper.kt
@@ -139,7 +139,7 @@ class ApkDownloadHelper constructor(private val context: Context) {
         }
     }
 
-    @Throws(NoSuchAlgorithmException::class, GeneralSecurityException::class)
+    @Throws(GeneralSecurityException::class)
     private fun verifyHash(downloadedFile: File, sha256Hash: String): Boolean {
         try {
             val downloadedFileHash = bytesToHex(


### PR DESCRIPTION
`verifyHash()` catches `NoSuchAlgorithmException` and rethrows it as
`GeneralSecurityException`, so it never actually throws
`NoSuchAlgorithmException` itself.