### PR TITLE
Use separate constant for signing key version

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/utils/network/Constant.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/network/Constant.kt
@@ -5,4 +5,5 @@ const val PACKAGE_DIR_URL = "${BASE_URL}/packages/"
 
 const val PUBLIC_KEY = "RWQtZwEu1br1lMh911L3yPOs97cQb9LOks/ALBbqGl21ul695ocWR/ir"
 const val TIMESTAMP = 1645702792
-const val CURRENT_VERSION = 0
+const val METADATA_VERSION = 0
+const val KEY_VERSION = 0

--- a/app/src/main/java/org/grapheneos/apps/client/utils/network/MetaDataHelper.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/network/MetaDataHelper.kt
@@ -24,10 +24,8 @@ import javax.net.ssl.SSLHandshakeException
 
 class MetaDataHelper constructor(context: Context) {
 
-    private val version = CURRENT_VERSION
-
-    private val metadataFileName = "metadata.${version}.json"
-    private val metadataSignFileName = "metadata.${version}.json.${version}.sig"
+    private val metadataFileName = "metadata.${METADATA_VERSION}.json"
+    private val metadataSignFileName = "metadata.${METADATA_VERSION}.json.${KEY_VERSION}.sig"
 
     private val baseDir = context.metadataVerifiedDir()
     private val tmpDir = context.metadataTmpDir()


### PR DESCRIPTION
This doesn't change anything functionally but is more correct since the
metadata version and key version are decoupled.