### PR TITLE
Make search input single line

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/ui/container/res/layout/activity_main.xml
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/container/res/layout/activity_main.xml
@@ -35,6 +35,8 @@
                 android:hint="@string/searchForApps"
                 android:imeOptions="actionSearch"
                 android:maxLines="1"
+                android:singleLine="true"
+                android:inputType="text"
                 android:padding="12dp"
                 android:textColor="?attr/colorControlNormal" />
 


### PR DESCRIPTION
Setting `android:MaxLine=1` alone did not seem to work as hitting the enter key still added a newline to the search text input.

Consequently, we also need to update the search query on `IME_ACTION_SEARCH`.