### PR TITLE
Add support for changing release channel of all apps

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/ui/detailsScreen/DetailsScreen.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/detailsScreen/DetailsScreen.kt
@@ -115,13 +115,15 @@ class DetailsScreen : Fragment() {
             }
             R.id.switchChannel -> {
                 val packageInfo = pkgInfo ?: return false
+                val savedPkgChannel = app.channelPreferenceManager
+                    .getPackageChannelOrNull(packageInfo.pkgName)
                 findNavController().navigate(
                     DetailsScreenDirections.actionDetailsScreenToSwitchChannel(
                         packageInfo.pkgName,
                         packageInfo.allVariant.map {
                             it.type
                         }.toTypedArray(),
-                        packageInfo.selectedVariant.type
+                        savedPkgChannel ?: getString(R.string.default_channel_indicator)
                     )
                 )
 

--- a/app/src/main/java/org/grapheneos/apps/client/ui/switchChannel/SwitchChannel.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/switchChannel/SwitchChannel.kt
@@ -20,14 +20,16 @@ class SwitchChannel : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 
-        val channels = mutableListOf<String>()
+        // 'default' is not an actual channel but an indicator to use the global default channel.
+        val channels = mutableListOf(getString(R.string.default_channel_indicator))
+        val initialChannelSize = channels.size
         var preSelectedIndex = 0
         var selectedIndex = preSelectedIndex
         for (i in 0 until args.channels.size) {
             val name = args.channels[i]
             channels.add(name)
             if (args.selectedChannel == name) {
-                preSelectedIndex = i
+                preSelectedIndex = initialChannelSize + i
             }
         }
 
@@ -38,7 +40,12 @@ class SwitchChannel : DialogFragment() {
             }
             .setCancelable(true)
             .setPositiveButton(resources.getString(R.string.select)) { _, _ ->
-                app.handleOnVariantChange(args.pkgName, channels[selectedIndex])
+                val channel = channels[selectedIndex]
+                if (channel == getString(R.string.default_channel_indicator)) {
+                    app.resetPackageChannel(args.pkgName)
+                } else {
+                    app.handleOnVariantChange(args.pkgName, channel)
+                }
                 findNavController().popBackStack()
             }
             .setNegativeButton(resources.getString(R.string.cancel)) { _, _ ->

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -42,4 +42,11 @@
         <item>Not roaming</item>
     </string-array>
 
+    <!--Channels-->
+    <string-array name="channelValues">
+        <item>stable</item>
+        <item>beta</item>
+        <item>alpha</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/psfs_keys.xml
+++ b/app/src/main/res/values/psfs_keys.xml
@@ -3,6 +3,7 @@
     <string name="autoUpdatePreferenceKey" translatable="false">seamlessUpdate</string>
     <string name="backgroundUpdatedEnabled" translatable="false">seamlessUpdateEnabled</string>
     <string name="seamlessInstallEnabled" translatable="false">seamlessInstallEnabled</string>
+    <string name="defaultChannelPreference" translatable="false">defaultChannelPreference</string>
     <string name="rescheduleTiming" translatable="false">rescheduleTiming</string>
     <string name="networkType" translatable="false">seamlessUpdateNetworkType</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,10 @@
     <string name="background_update_duration_title">Auto download app updates interval</string>
     <string name="background_update_duration_summary">Check for available updates after selected number of hours</string>
 
+    <!-- Default channel preference -->
+    <string name="default_channel_title">Default release channel</string>
+    <string name="default_channel_summary">Set default release channel for all apps</string>
+
     <!--Notifications-->
     <string name="suGroupName">Seamless updates</string>
     <string name="suGroupDescription">Notification regarding seamless updates</string>
@@ -139,6 +143,7 @@
     <string name="release_channel">Release Channel</string>
     <string name="select">Select</string>
     <string name="cancel">Cancel</string>
+    <string name="default_channel_indicator">default</string>
 
 
     <string name="ok">OK</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -22,6 +22,14 @@
             app:summaryOn="@string/auto_install_summary_on"
             app:title="@string/auto_install_title" />
 
+        <ListPreference
+            app:defaultValue="@string/channel_default"
+            app:entries="@array/channelValues"
+            app:entryValues="@array/channelValues"
+            app:key="@string/defaultChannelPreference"
+            app:summary="@string/default_channel_summary"
+            app:title="@string/default_channel_title" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This resolves #137 by doing two things:
1. Adds setting for changing the default channel for all apps, in the main settings screen.
2. Adds support for resetting the channel in per-app release channel settings.

No regressions in initial testing. I need some help testing it, since I can't confirm if changing channel with the new setting works and user gets the app from appropriate channel. Although, it should logically as per the code.