### PR TITLE
bugfix: Only trigger navigation to search screen when it's not from itself

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/ui/container/MainActivity.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/container/MainActivity.kt
@@ -127,8 +127,8 @@ class MainActivity : AppCompatActivity() {
             currentDestinations = destination.id
             updateUi()
         }
-        views.searchInput.setOnClickListener { navCtrl.navigate(R.id.searchScreen) }
-        views.searchBar.setOnClickListener { navCtrl.navigate(R.id.searchScreen) }
+        views.searchInput.setOnClickListener { if (!isSearchScreen) navCtrl.navigate(R.id.searchScreen) }
+        views.searchBar.setOnClickListener { if (!isSearchScreen) navCtrl.navigate(R.id.searchScreen) }
         app.updateCount.observe(this, obs)
         app.packageLiveData.observe(this, packagesObserver)
 


### PR DESCRIPTION


Do not call `navigate()` on tapping search bar when it's already at the search screen, to avoid multiple back presses needed to go back at previous screen