### PR TITLE
Improve exposed refresh functionality and bugfixes

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/service/KeepAppActive.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/service/KeepAppActive.kt
@@ -15,7 +15,7 @@ class KeepAppActive : Service() {
     private val app: App by lazy { applicationContext as App }
 
     private val observer = Observer<Boolean> { isDownloadRunning ->
-        if (isDownloadRunning) stopService()
+        if (!isDownloadRunning) stopService()
     }
 
 

--- a/app/src/main/java/org/grapheneos/apps/client/ui/container/MainActivity.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/container/MainActivity.kt
@@ -68,12 +68,17 @@ class MainActivity : AppCompatActivity() {
     var isMainScreen = false
     var isSearchScreen = false
     var currentDestinations = -1
-    private val packagesObserver = Observer<Map<String, PackageInfo>> { updateUi(it.isNotEmpty()) }
+    var hasSyncedSuccessfully = false
+    private val packagesObserver = Observer<Map<String, PackageInfo>> {
+        hasSyncedSuccessfully = it.isNotEmpty()
+        updateUi(it.isNotEmpty())
+    }
 
     private fun updateUi(isSyncFinished: Boolean = app.isSyncingSuccessful()) {
-        views.searchBar.isVisible = (isMainScreen || isSearchScreen) && isSyncFinished
-        views.searchTitle.isVisible = isMainScreen && isSyncFinished
-        views.searchInput.isVisible = isSearchScreen && isSyncFinished
+        views.searchBar.isVisible = (isMainScreen || isSearchScreen)
+            && (isSyncFinished || hasSyncedSuccessfully)
+        views.searchTitle.isVisible = isMainScreen && (isSyncFinished || hasSyncedSuccessfully)
+        views.searchInput.isVisible = isSearchScreen && (isSyncFinished || hasSyncedSuccessfully)
         views.bottomNavView.isGone =
             !appBarConfiguration.topLevelDestinations.contains(currentDestinations) || !isSyncFinished
         if (isSearchScreen) {

--- a/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/AppsListAdapter.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/AppsListAdapter.kt
@@ -11,7 +11,7 @@ import org.grapheneos.apps.client.utils.AppSourceHelper
 
 class AppsListAdapter(private val mainScreen: MainScreen) :
     ListAdapter<InstallablePackageInfo, AppsListAdapter.AppsListViewHolder>(
-        InstallablePackageInfo.UiItemDiff()
+        InstallablePackageInfo.UiItemDiff(isDownloadUi = true)
     ) {
 
     inner class AppsListViewHolder(private val binding: ItemAppsBinding) :

--- a/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/MainScreen.kt
@@ -68,6 +68,11 @@ class MainScreen : Fragment() {
         }
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        menu.findItem(R.id.refresh).isVisible = !binding.swipeRefresh.isRefreshing
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -179,6 +184,7 @@ class MainScreen : Fragment() {
     }
 
     private fun updateUi(isSyncingResultSuccess: Boolean? = null) {
+        requireActivity().invalidateOptionsMenu()
         val isFirstScreen = lastItems.isNullOrEmpty()
         val isSyncing = isSyncingResultSuccess == null
         val isSuccess = isSyncingResultSuccess ?: false

--- a/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/MainScreen.kt
@@ -108,7 +108,11 @@ class MainScreen : Fragment() {
                 state.modifyFilter(state.buildByGrapheneOs, isChecked)
             }
             swipeRefresh.setOnRefreshListener {
-                refresh(isForcedUpdate = !lastItems.isNullOrEmpty())
+                if (appsViewModel.isDownloading) {
+                    binding.swipeRefresh.isRefreshing = false
+                    return@setOnRefreshListener
+                }
+                refresh(true)
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="otherAppsDownloadInProgress">Dependencies or other apps are in progress of being downloaded and/or installed</string>
     <string name="allowUnknownSources">You must allow installation from this source first</string>
     <string name="newerVersionIsInstalled">Newer version is already installed</string>
+    <string name="pendingAppDownload">Please wait for package to get downloaded</string>
 
     <!--details_screen.xml-->
     <string name="installed">Installed</string>


### PR DESCRIPTION
This changeset includes 

-  disallowing refresh and download at the same time

- updating the button when downloaded from the app list screen, and

- improving view elements visibility when refresh is triggered