### PR TITLE
Bugfix: Set appName TextView width to wrap_content

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/res/layout/item_apps.xml
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/res/layout/item_apps.xml
@@ -19,7 +19,7 @@
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/appName"
             style="@style/TextAppearance.Material3.LabelLarge"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toStartOf="@+id/releaseTag"

--- a/app/src/main/java/org/grapheneos/apps/client/ui/search/res/layout/item_search.xml
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/search/res/layout/item_search.xml
@@ -19,7 +19,7 @@
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/appName"
             style="@style/TextAppearance.Material3.LabelLarge"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toStartOf="@+id/releaseTag"


### PR DESCRIPTION
This fixes a bug where doing refresh or changing filters can cause the position of the releaseTag TextView to shift by a random amount to the right as it is constrained to the appName TextView

Fixes #216