### PR TITLE
Exclude extraneous bouncycastle .properties files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,12 @@ android {
             }
         }
     }
+    packagingOptions {
+        resources.excludes.addAll(listOf(
+            "org/bouncycastle/pqc/**.properties",
+            "org/bouncycastle/x509/**.properties",
+        ))
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The update to bouncycastle 1.72 in a3bdc7f inadvertently added about 4 MiB of .properties files (as a result of bouncycastle's new Picnic and SIKE implementations) to optimized release builds, increasing their size by ~168%. Since we're not using bouncycastle for these algorithms, exclude the extraneous files to reduce app size.