### PR TITLE
fix(layout): use 8dp max padding between cards

### DIFF
--- a/app/src/main/res/layout/package_list_item.xml
+++ b/app/src/main/res/layout/package_list_item.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="8dp"
-    android:layout_marginVertical="8dp"
+    android:layout_marginVertical="4dp"
     android:clickable="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
The layout should have a maximum padding of 8dp between cards. Reference: https://m3.material.io/components/cards/specs#9abbced9-d5d3-4893-9a67-031825205f06

It's expected that this card will be included in views such as a dynamic list. Using a 4dp vertical margin results in an 8dp margin between the cards.


Fixes https://github.com/GrapheneOS/Apps/issues/289