### PR TITLE
reimplement auto-update functionality 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,11 @@
 
         <service
             android:exported="false"
+            android:name=".autoupdate.UpdateCheckJob"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
+        <service
+            android:exported="false"
             android:name=".autoupdate.AutoUpdateJob"
             android:permission="android.permission.BIND_JOB_SERVICE" />
 

--- a/app/src/main/java/app/grapheneos/apps/ApplicationImpl.kt
+++ b/app/src/main/java/app/grapheneos/apps/ApplicationImpl.kt
@@ -8,9 +8,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
-import androidx.core.os.postDelayed
 import app.grapheneos.apps.autoupdate.AutoUpdatePrefs
-import app.grapheneos.apps.core.mainHandler
 import app.grapheneos.apps.core.notificationManager
 import app.grapheneos.apps.util.ActivityUtils
 import com.google.android.material.color.DynamicColors
@@ -24,6 +22,7 @@ class ApplicationImpl : Application(), ActivityLifecycleCallbacks {
 
         const val TAG = "ApplicationImpl"
         const val JOB_SCHEDULER_JOB_ID_AUTO_UPDATE = 1000
+        const val JOB_SCHEDULER_JOB_ID_UPDATE_CHECK = 1001
 
         fun exitIfNotInitialized() {
             if (baseAppContext == null) {
@@ -47,12 +46,7 @@ class ApplicationImpl : Application(), ActivityLifecycleCallbacks {
         Notifications.init(activeNotifications)
         ActivityUtils.init(activeNotifications)
 
-        // if the MainActivity is being launched for the first time, AutoUpdateJob would be executed
-        // before it launches, which breaks the check in AutoUpdateJob that skips the job when
-        // an activity is visible. Delay the job setup to avoid this.
-        mainHandler.postDelayed(3000) {
-            AutoUpdatePrefs.setupJob()
-        }
+        AutoUpdatePrefs.setupJobs()
 
         DynamicColors.applyToActivitiesIfAvailable(this)
         registerActivityLifecycleCallbacks(this)

--- a/app/src/main/java/app/grapheneos/apps/Notifications.kt
+++ b/app/src/main/java/app/grapheneos/apps/Notifications.kt
@@ -28,6 +28,7 @@ object Notifications {
     const val CH_AUTO_UPDATE_UPDATES_AVAILABLE = "auto_update_job_updates_available"
     const val CH_AUTO_UPDATE_CONFIRMATION_REQUIRED = "auto_update_job_confirmation_required"
     const val CH_AUTO_UPDATE_FAILED = "auto_update_job_failed"
+    const val CH_BACKGROUND_UPDATE_CHECK_FAILED = "update_check_failed"
 
     const val CH_CONFIRMATION_REQUIRED = "confirmation_required"
     const val CH_MISSING_DEPENDENCY = "dependency_error"
@@ -64,6 +65,7 @@ object Notifications {
             ch(CH_INSTALLATION_FAILED, R.string.notif_installation_failed, IMPORTANCE_HIGH),
             ch(CH_PACKAGE_DOWNLOAD, R.string.notif_ch_downloading_app, IMPORTANCE_DEFAULT),
             ch(CH_MISSING_DEPENDENCY, R.string.notif_missing_dependency, IMPORTANCE_DEFAULT),
+            ch(CH_BACKGROUND_UPDATE_CHECK_FAILED, R.string.notif_ch_background_update_check_failed)
         )
 
         channels.addAll(autoUpdateChannels)

--- a/app/src/main/java/app/grapheneos/apps/RpcProvider.kt
+++ b/app/src/main/java/app/grapheneos/apps/RpcProvider.kt
@@ -10,6 +10,7 @@ import android.os.Message
 import android.os.Messenger
 import android.util.Log
 import app.grapheneos.apps.autoupdate.AutoUpdatePrefs
+import app.grapheneos.apps.core.InstallParams
 import app.grapheneos.apps.core.PackageInstallerError
 import app.grapheneos.apps.core.PackageState
 import app.grapheneos.apps.core.startPackageInstall
@@ -93,9 +94,11 @@ class RpcProvider : ContentProvider() {
             return false
         }
 
+        val installParams = InstallParams(network = null, isUpdate = true, isUserInitiated = false)
+
         try {
             val installError: PackageInstallerError? =
-                startPackageInstall(pkg, isUserInitiated = false, isUpdate = true).await().await()
+                startPackageInstall(pkg, installParams).await().await()
             return installError == null
         } catch (e: Throwable) {
             Log.d(TAG, "", e)

--- a/app/src/main/java/app/grapheneos/apps/autoupdate/AutoUpdateJob.kt
+++ b/app/src/main/java/app/grapheneos/apps/autoupdate/AutoUpdateJob.kt
@@ -74,7 +74,7 @@ class AutoUpdateJob : JobService() {
                     activeJobs = null
                 }
             } else {
-                Notifications.builder(Notifications.CH_AUTO_UPDATE_FAILED).run {
+                Notifications.builder(Notifications.CH_BACKGROUND_UPDATE_CHECK_FAILED).run {
                     setSmallIcon(R.drawable.ic_error)
                     setContentTitle(R.string.unable_to_fetch_app_list)
                     setContentIntent(ErrorDialog.createPendingIntent(repoUpdateError))

--- a/app/src/main/java/app/grapheneos/apps/autoupdate/AutoUpdatePrefs.kt
+++ b/app/src/main/java/app/grapheneos/apps/autoupdate/AutoUpdatePrefs.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.core.content.getSystemService
 import app.grapheneos.apps.ApplicationImpl.Companion.JOB_SCHEDULER_JOB_ID_AUTO_UPDATE
+import app.grapheneos.apps.ApplicationImpl.Companion.JOB_SCHEDULER_JOB_ID_UPDATE_CHECK
 import app.grapheneos.apps.R
 import app.grapheneos.apps.core.appContext
 import app.grapheneos.apps.core.appResources
@@ -23,79 +24,135 @@ object AutoUpdatePrefs {
     private val jobScheduler: JobScheduler = appContext.getSystemService()!!
     private val prefs = getSharedPreferences(R.string.pref_file_settings)
 
-    fun isBackgroundUpdateCheckEnabled() = prefs.getBoolean(
+    private fun isBackgroundUpdateCheckEnabled() = prefs.getBoolean(
         KEY_BG_UPDATE_CHECK_ENABLED, appResources.getBoolean(R.bool.pref_def_background_update_check))
 
-    fun isPackageAutoUpdateEnabled() = prefs.getBoolean(
+    private fun isPackageAutoUpdateEnabled() = prefs.getBoolean(
         KEY_PKG_AUTO_UPDATE_ENABLED, appResources.getBoolean(R.bool.pref_def_auto_update_packages))
 
-    private fun jobNetworkType(): Int {
-        return when (bgUpdateJobNetworkType()) {
+    private fun getAutoUpdateJobNetworkTypePref(): Int =
+        prefs.getString(KEY_JOB_NETWORK_TYPE, null)?.toInt() ?:
+        appResources.getString(R.string.pref_def_network_type_for_bg_update_job).toInt()
+
+    private fun getAutoUpdateJobNetworkType(): Int {
+        return when (getAutoUpdateJobNetworkTypePref()) {
             2 -> JobInfo.NETWORK_TYPE_UNMETERED
             3 -> JobInfo.NETWORK_TYPE_NOT_ROAMING
             else -> JobInfo.NETWORK_TYPE_ANY
         }
     }
 
-    private fun jobRepeatIntervalMillis() =
+    private fun getUpdateCheckIntervalMillis() =
         prefs.getString(KEY_JOB_REPEAT_INTERVAL, null)?.toLong() ?:
         appResources.getString(R.string.pref_def_background_update_check_interval).toLong()
-
-    private fun bgUpdateJobNetworkType(): Int =
-        prefs.getString(KEY_JOB_NETWORK_TYPE, null)?.toInt() ?:
-        appResources.getString(R.string.pref_def_network_type_for_bg_update_job).toInt()
 
     fun isAllowedToAutoUpdateNoCodePackages(): Boolean {
         return isPackageAutoUpdateEnabled() || prefs.getBoolean(
             appResources.getString(R.string.pref_key_always_allow_nocode_updates),
             appResources.getBoolean(R.bool.pref_def_always_allow_noCode_updates))
     }
-    fun setupJob() {
-        updateJob()
+
+    // Auto update is implemented in the following way:
+    // There are 2 jobs: update check job and auto update job.
+    //
+    // Update check job runs periodically, its only constraint is the presence of network connection.
+    // If update check job determines that there are available updates, then it shows the "updates
+    // available" notification and schedules the auto update job.
+    //
+    // Auto update job is allowed to run only when the device is idle, to avoid updating packages
+    // that are in use, and to not take up network bandwidth that is more likely to be scarce when
+    // the device is being used. Auto update job supports network type constraints.
+    //
+    // Both of the jobs can be disabled by the user.
+
+    fun setupJobs() {
+        updateJobs()
         // note that listener must be strongly referenced to work
         prefs.registerOnSharedPreferenceChangeListener(sharedPrefsChangeListener)
     }
 
     val sharedPrefsChangeListener = SharedPreferences.OnSharedPreferenceChangeListener  { _, key ->
         if (key == KEY_BG_UPDATE_CHECK_ENABLED || key == KEY_JOB_NETWORK_TYPE || key == KEY_JOB_REPEAT_INTERVAL) {
-            updateJob()
+            updateJobs()
         }
     }
 
-    private fun updateJob() {
-        val pendingJob = jobScheduler.getPendingJob(JOB_SCHEDULER_JOB_ID_AUTO_UPDATE)
+    private fun updateJobs() {
+        val pendingJobs = jobScheduler.getAllPendingJobs()
+
+        val pendingUpdateCheckJob = pendingJobs.find { it.id == JOB_SCHEDULER_JOB_ID_UPDATE_CHECK }
+        val pendingAutoUpdateJob = pendingJobs.find { it.id == JOB_SCHEDULER_JOB_ID_AUTO_UPDATE }
 
         if (!isBackgroundUpdateCheckEnabled()) {
-            if (pendingJob != null) {
-                jobScheduler.cancel(JOB_SCHEDULER_JOB_ID_AUTO_UPDATE)
-                Log.d(TAG, "job cancelled")
+            if (pendingUpdateCheckJob != null) {
+                jobScheduler.cancel(JOB_SCHEDULER_JOB_ID_UPDATE_CHECK)
+                Log.d(TAG, "update check job cancelled: $pendingUpdateCheckJob")
             }
+
+            if (pendingAutoUpdateJob != null) {
+                jobScheduler.cancel(JOB_SCHEDULER_JOB_ID_AUTO_UPDATE)
+                Log.d(TAG, "auto-update job cancelled: $pendingAutoUpdateJob")
+            }
+
             return
         }
 
-        val networkType = jobNetworkType()
-        val repeatInterval = jobRepeatIntervalMillis()
+        if (pendingAutoUpdateJob?.isPeriodic() == true) {
+            // this is a leftover job from a previous app version
+            jobScheduler.cancel(JOB_SCHEDULER_JOB_ID_AUTO_UPDATE)
+        }
 
-        // no way to read back the network type without the deprecated getNetworkType() method
-        @Suppress("DEPRECATION")
+        scheduleUpdateCheckJob(pendingUpdateCheckJob)
+    }
+
+    private fun scheduleUpdateCheckJob(pendingJob: JobInfo?) {
+        val repeatInterval = getUpdateCheckIntervalMillis()
+
         if (pendingJob != null
-            && pendingJob.networkType == networkType
             && pendingJob.intervalMillis == repeatInterval
-            && pendingJob.service.className == AutoUpdateJob::class.java.name
+            && pendingJob.service.className == UpdateCheckJob::class.java.name
         ) {
             return
         }
 
-        val jobInfo = JobInfo.Builder(JOB_SCHEDULER_JOB_ID_AUTO_UPDATE, componentName<AutoUpdateJob>()).run {
-            setRequiredNetworkType(jobNetworkType())
+        val jobInfo = JobInfo.Builder(JOB_SCHEDULER_JOB_ID_UPDATE_CHECK, componentName<UpdateCheckJob>()).run {
+            setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
             setPersisted(true)
-            setPeriodic(jobRepeatIntervalMillis())
-            // TODO consider using setRequiresDeviceIdle(), together with setOverrideDeadline()
-            //  (will require removing setPeriodic() and rescheduling manually)
+            setPeriodic(repeatInterval)
             build()
         }
 
-        jobScheduler.schedule(jobInfo)
-        Log.d(TAG, "job scheduled, interval: ${jobInfo.intervalMillis}")
+        val scheduleRes = jobScheduler.schedule(jobInfo)
+        if (scheduleRes == JobScheduler.RESULT_SUCCESS) {
+            Log.d(TAG, "update check job scheduled, interval: ${jobInfo.intervalMillis}")
+        } else {
+            Log.d(TAG, "unable to schedule update check job, schedule result: $scheduleRes")
+        }
+    }
+
+    fun maybeScheduleAutoUpdateJob() {
+        if (!isPackageAutoUpdateEnabled()) {
+            return
+        }
+
+        val jobInfo = JobInfo.Builder(JOB_SCHEDULER_JOB_ID_AUTO_UPDATE, componentName<AutoUpdateJob>()).run {
+            setRequiredNetworkType(getAutoUpdateJobNetworkType())
+            // As of Android 13, "device is idle" is defined in the following way:
+            // - screen is off (or device is docked) for 31 minutes (+ 5 minutes slop)
+            // - device does not have an active UI projection (eg Android Auto)
+            //
+            // Package is force-stopped when installation starts and remains unusable for the whole duration of
+            // installation, which can take over a minute on GrapheneOS due to the full AOT compilation.
+            setRequiresDeviceIdle(true)
+            setPersisted(true)
+            build()
+        }
+
+        val scheduleRes = jobScheduler.schedule(jobInfo)
+        if (scheduleRes == JobScheduler.RESULT_SUCCESS) {
+            Log.d(TAG, "auto update job scheduled")
+        } else {
+            Log.d(TAG, "unable to schedule auto update job, schedule result: $scheduleRes")
+        }
     }
 }

--- a/app/src/main/java/app/grapheneos/apps/autoupdate/UpdateCheckJob.kt
+++ b/app/src/main/java/app/grapheneos/apps/autoupdate/UpdateCheckJob.kt
@@ -1,0 +1,137 @@
+package app.grapheneos.apps.autoupdate
+
+import android.app.Notification
+import android.app.job.JobParameters
+import android.app.job.JobService
+import android.text.format.Formatter
+import android.util.Log
+import androidx.navigation.NavDeepLinkBuilder
+import app.grapheneos.apps.ApplicationImpl
+import app.grapheneos.apps.Notifications
+import app.grapheneos.apps.PackageStates
+import app.grapheneos.apps.R
+import app.grapheneos.apps.core.RPackage
+import app.grapheneos.apps.core.RepoUpdateError
+import app.grapheneos.apps.core.appContext
+import app.grapheneos.apps.core.appResources
+import app.grapheneos.apps.core.collectOutdatedPackageGroups
+import app.grapheneos.apps.setContentTitle
+import app.grapheneos.apps.show
+import app.grapheneos.apps.ui.DetailsScreen
+import app.grapheneos.apps.ui.ErrorDialog
+import app.grapheneos.apps.ui.MainActivity
+import app.grapheneos.apps.util.componentName
+import app.grapheneos.apps.util.isAppInstallationAllowed
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+private const val TAG = "UpdateCheckJob"
+
+class UpdateCheckJob : JobService() {
+
+    override fun onStartJob(jobParams: JobParameters?): Boolean {
+        ApplicationImpl.exitIfNotInitialized()
+        Log.d(TAG, "onStartJob")
+
+        if (!isAppInstallationAllowed()) {
+            return false
+        }
+
+        CoroutineScope(Dispatchers.Main).launch {
+            val repoUpdateError = PackageStates.requestRepoUpdate()
+            if (repoUpdateError != null) {
+                showUpdateCheckFailedNotification(repoUpdateError)
+            } else {
+                val outdatedPackageGroups = collectOutdatedPackageGroups()
+
+                if (outdatedPackageGroups.isEmpty()) {
+                    showAllUpToDateNotification()
+                } else {
+                    showUpdatesAvailableNotification(outdatedPackageGroups)
+
+                    AutoUpdatePrefs.maybeScheduleAutoUpdateJob()
+                }
+            }
+
+            jobFinished(jobParams, false)
+            Log.d(TAG, "finished")
+        }
+
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters): Boolean {
+        // ignore the stop signal: update check is inexpensive and doesn't have relevant cancellation points
+        return false
+    }
+
+    private fun showUpdatesAvailableNotification(rPackageGroups: List<List<RPackage>>) {
+        val rPackages = ArrayList<RPackage>()
+        rPackageGroups.forEach { it.forEach { rPackages.add(it) } }
+
+        check(rPackages.size >= 1)
+
+        val filteredRPackages = rPackages.filter { it.common.showAutoUpdateNotifications }
+
+        if (filteredRPackages.isEmpty()) {
+            return
+        }
+
+        val config = appResources.configuration
+        val sumSize = rPackages.sumOf {
+            it.collectNeededApks(config).sumOf { it.compressedSize }
+        }.let {
+            Formatter.formatShortFileSize(appContext, it)
+        }
+
+        Notifications.builder(Notifications.CH_AUTO_UPDATE_UPDATES_AVAILABLE).apply {
+            setSmallIcon(R.drawable.ic_updates_available)
+
+            setContentTitle(
+                appResources.getQuantityString(R.plurals.notif_pkg_updates_available_title,
+                rPackages.size, sumSize))
+            if (filteredRPackages.size == 1) {
+                val rpkg = filteredRPackages[0]
+                setContentText(
+                    appResources.getString(R.string.notif_pkg_update_available_text,
+                    rpkg.label, rpkg.versionName))
+                setContentIntent(DetailsScreen.createPendingIntent(rpkg.packageName))
+            } else {
+                setContentText(filteredRPackages.map { it.label }.joinToString())
+                NavDeepLinkBuilder(appContext).run {
+                    setGraph(R.navigation.nav_graph)
+                    setDestination(R.id.updates_screen)
+                    setComponentName(componentName<MainActivity>())
+                    createPendingIntent()
+                }.let {
+                    setContentIntent(it)
+                }
+            }
+            setStyle(Notification.BigTextStyle())
+            show(Notifications.ID_AUTO_UPDATE_JOB_STATUS)
+        }
+    }
+}
+
+fun showAllUpToDateNotification() {
+    if (PackageStates.numberOfInstallTasks() != 0) {
+        return
+    }
+
+    Notifications.builder(Notifications.CH_AUTO_UPDATE_ALL_UP_TO_DATE).run {
+        setSmallIcon(R.drawable.ic_check)
+        setContentTitle(R.string.notif_auto_update_all_up_to_date)
+        setAutoCancel(false)
+        show(Notifications.ID_AUTO_UPDATE_JOB_STATUS)
+    }
+}
+
+fun showUpdateCheckFailedNotification(repoUpdateError: RepoUpdateError) {
+    Notifications.builder(Notifications.CH_BACKGROUND_UPDATE_CHECK_FAILED).run {
+        setSmallIcon(R.drawable.ic_error)
+        setContentTitle(R.string.unable_to_fetch_app_list)
+        setContentIntent(ErrorDialog.createPendingIntent(repoUpdateError))
+        show(Notifications.ID_AUTO_UPDATE_JOB_STATUS)
+    }
+}

--- a/app/src/main/java/app/grapheneos/apps/core/PackageState.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/PackageState.kt
@@ -96,7 +96,7 @@ class PackageState(val pkgName: String, val id: Long) {
                         appendDots(sb)
                         sb.toString()
                     } else {
-                        val ref = if (task.isUpdate) R.string.pkg_status_downloading_update
+                        val ref = if (task.params.isUpdate) R.string.pkg_status_downloading_update
                             else R.string.pkg_status_downloading
                         val percent = ((progress.toDouble() / total.toDouble()) * 100.0).toInt()
                         ctx.getString(ref, percent,

--- a/app/src/main/java/app/grapheneos/apps/core/PackageStates.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/PackageStates.kt
@@ -308,6 +308,11 @@ object PackageStates : LifecycleEventObserver {
         }
     }
 
+    fun numberOfInstallTasks(): Int {
+        checkMainThread()
+        return installTasks.size
+    }
+
     private var pendingCachePruning = false
     private var periodicCachePruningScheduled = false
 

--- a/app/src/main/java/app/grapheneos/apps/core/PkgInstallerStatusReceiver.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/PkgInstallerStatusReceiver.kt
@@ -14,6 +14,7 @@ import android.util.SparseArray
 import app.grapheneos.apps.Notifications
 import app.grapheneos.apps.PackageStates
 import app.grapheneos.apps.R
+import app.grapheneos.apps.autoupdate.showAllUpToDateNotification
 import app.grapheneos.apps.setContentTitle
 import app.grapheneos.apps.show
 import app.grapheneos.apps.ui.DetailsScreen
@@ -152,6 +153,10 @@ class PkgInstallerStatusReceiver: BroadcastReceiver() {
                 check(completionChannel.trySend(null).isSuccess)
             }
 
+            if (collectOutdatedPackageGroups().isEmpty()) {
+                showAllUpToDateNotification()
+            }
+
             if (request.isUserInitiated) {
                 return
             }
@@ -169,6 +174,7 @@ class PkgInstallerStatusReceiver: BroadcastReceiver() {
                     show(Notifications.generateId())
                 }
             }
+
             return
         }
 

--- a/app/src/main/java/app/grapheneos/apps/core/RepoRetriever.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/RepoRetriever.kt
@@ -22,7 +22,7 @@ import java.security.GeneralSecurityException
 private const val METADATA_VERSION = 1
 private const val CACHE_FILE_VERSION = 1
 
-private const val MIN_TIMESTAMP = 1_671_556_700L
+private const val MIN_TIMESTAMP = 1_680_000_000L
 private const val PUBLIC_KEY = BuildConfig.REPO_PUBLIC_KEY
 private const val KEY_VERSION = BuildConfig.REPO_KEY_VERSION
 

--- a/app/src/main/java/app/grapheneos/apps/core/RepoRetriever.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/RepoRetriever.kt
@@ -32,7 +32,7 @@ fun fetchRepo(currentRepo: Repo): Repo {
     val url = "$REPO_BASE_URL/metadata.$METADATA_VERSION.$KEY_VERSION.sjson"
 
     return if (!currentRepo.isDummy) {
-        openConnection(url) {
+        openConnection(null, url) {
             setRequestProperty("If-None-Match", currentRepo.eTag)
         }.use { conn ->
             when (conn.v.responseCode) {
@@ -48,7 +48,7 @@ fun fetchRepo(currentRepo: Repo): Repo {
             }
         }
     } else {
-        openConnection(url, {}).use { conn ->
+        openConnection(null, url, {}).use { conn ->
             if (conn.v.responseCode != HTTP_OK) {
                 throwResponseCodeException(conn.v)
             }

--- a/app/src/main/java/app/grapheneos/apps/ui/UpdatesScreen.kt
+++ b/app/src/main/java/app/grapheneos/apps/ui/UpdatesScreen.kt
@@ -12,7 +12,8 @@ import app.grapheneos.apps.PackageStates
 import app.grapheneos.apps.R
 import app.grapheneos.apps.core.InstallParams
 import app.grapheneos.apps.core.PackageState
-import app.grapheneos.apps.core.updateAllPackages
+import app.grapheneos.apps.core.collectOutdatedPackageGroups
+import app.grapheneos.apps.core.startPackageUpdate
 import app.grapheneos.apps.databinding.UpdatesScreenBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -51,9 +52,10 @@ class UpdatesScreen : PackageListFragment<UpdatesScreenBinding>(), MenuProvider 
             updateList()
 
             CoroutineScope(Dispatchers.Main).launch {
-                val installParams = InstallParams(network = null, isUserInitiated = true, isUpdate = true)
-                val jobs = updateAllPackages(installParams)
-                if (jobs.isNotEmpty()) {
+                val outdatedPackageGroups = collectOutdatedPackageGroups()
+                if (outdatedPackageGroups.isNotEmpty()) {
+                    val installParams = InstallParams(network = null, isUserInitiated = true, isUpdate = true)
+                    val jobs = startPackageUpdate(installParams, outdatedPackageGroups)
                     model.cancelableJobs = jobs
                     PackageStates.dispatchAllStatesChanged()
                     try {

--- a/app/src/main/java/app/grapheneos/apps/ui/UpdatesScreen.kt
+++ b/app/src/main/java/app/grapheneos/apps/ui/UpdatesScreen.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import app.grapheneos.apps.PackageStates
 import app.grapheneos.apps.R
+import app.grapheneos.apps.core.InstallParams
 import app.grapheneos.apps.core.PackageState
 import app.grapheneos.apps.core.updateAllPackages
 import app.grapheneos.apps.databinding.UpdatesScreenBinding
@@ -50,7 +51,8 @@ class UpdatesScreen : PackageListFragment<UpdatesScreenBinding>(), MenuProvider 
             updateList()
 
             CoroutineScope(Dispatchers.Main).launch {
-                val jobs = updateAllPackages(isUserInitiated = true)
+                val installParams = InstallParams(network = null, isUserInitiated = true, isUpdate = true)
+                val jobs = updateAllPackages(installParams)
                 if (jobs.isNotEmpty()) {
                     model.cancelableJobs = jobs
                     PackageStates.dispatchAllStatesChanged()

--- a/app/src/main/java/app/grapheneos/apps/util/HttpUtils.kt
+++ b/app/src/main/java/app/grapheneos/apps/util/HttpUtils.kt
@@ -1,12 +1,17 @@
 package app.grapheneos.apps.util
 
+import android.net.Network
 import java.net.HttpURLConnection
 import java.net.ProtocolException
 import java.net.URL
-import javax.net.ssl.HttpsURLConnection
 
-inline fun openConnection(url: String, configure: HttpURLConnection.() -> Unit): ScopedHttpConnection {
-    val connection = URL(url).openConnection() as HttpURLConnection
+inline fun openConnection(network: Network?, urlString: String, configure: HttpURLConnection.() -> Unit): ScopedHttpConnection {
+    val url = URL(urlString)
+    val connection = if (network != null) {
+        network.openConnection(url)
+    } else {
+        url.openConnection()
+    } as HttpURLConnection
 
     connection.apply {
         connectTimeout = 10_000

--- a/app/src/main/res/layout/details_screen.xml
+++ b/app/src/main/res/layout/details_screen.xml
@@ -17,6 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingHorizontal="8dp"
+            android:paddingBottom="4dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:layout_height="64dp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="notif_auto_update_updated_package_text">Updated %1$s to version %2$s</string>
     <string name="notif_ch_auto_update_confirmation_required">Confirmation required</string>
     <string name="notif_ch_auto_update_failed">Auto-update failed</string>
+    <string name="notif_ch_background_update_check_failed">Background update check failed</string>
     <string name="notif_ch_updates_available">Updates available</string>
 
     <string name="notif_pkg_update_available_text">%1$s, version %2$s</string>


### PR DESCRIPTION
- split it up into 2 jobs: update check job and auto update job (see comment in
AutoUpdatePrefs.setupJobs())
- refactor code in InstallStart to support this new split setup
- make sure that "Apps are up-to-date" notification is shown even if our process was killed while
the OS was installing submitted app updates by moving the code that shows this notification into the
package install status receiver (if our process was killed, it'll be spawned again by the OS to
instantiate this receiver)