### PR TITLE
support updating disabled packages on compatible OS versions

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/core/Globals.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/Globals.kt
@@ -38,6 +38,10 @@ val pkgInstaller: PackageInstaller = pkgManager.packageInstaller
 val isPrivilegedInstaller = appContext.checkSelfPermission(Manifest.permission.INSTALL_PACKAGES) ==
     PackageManager.PERMISSION_GRANTED
 
+// TODO add support for Android 14 after its API is finalized
+///  (PackageInstaller.SessionParams.setApplicationEnabledSettingPersistent())
+val canUpdateDisabledPackages = pkgManager.hasSystemFeature("grapheneos.package_update_preserves_package_enabled_setting")
+
 val notificationManager: NotificationManager = appContext.getSystemService()!!
 
 val userManager: UserManager = appContext.getSystemService()!!

--- a/app/src/main/java/app/grapheneos/apps/core/PackageState.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/PackageState.kt
@@ -128,7 +128,7 @@ class PackageState(val pkgName: String, val id: Long) {
         }
 
         val ai = pi.applicationInfo
-        if (!ai.enabled) {
+        if (!canUpdateDisabledPackages && !ai.enabled) {
             return ctx.getString(R.string.pkg_status_disabled)
         }
 
@@ -136,12 +136,17 @@ class PackageState(val pkgName: String, val id: Long) {
             return ctx.getString(R.string.pkg_status_update_available, getDownloadSizeUiString())
         }
 
+        if (!ai.enabled) {
+            return ctx.getString(R.string.pkg_status_disabled)
+        }
+
         return ctx.getString(R.string.pkg_status_installed)
     }
 
     fun isOutdated(): Boolean {
         val pi = osPackageInfo
-        return pi != null && pi.applicationInfo.enabled && pi.longVersionCode < rPackage.versionCode
+        return pi != null && (canUpdateDisabledPackages || pi.applicationInfo.enabled)
+                && pi.longVersionCode < rPackage.versionCode
     }
 
     fun status(): Status {
@@ -158,12 +163,17 @@ class PackageState(val pkgName: String, val id: Long) {
             return Status.NOT_INSTALLED
         }
 
-        if (!pi.applicationInfo.enabled) {
+        val ai = pi.applicationInfo
+        if (!canUpdateDisabledPackages && !ai.enabled) {
             return Status.DISABLED
         }
 
         if (pi.longVersionCode < rPackage.versionCode) {
             return Status.OUT_OF_DATE
+        }
+
+        if (!ai.enabled) {
+            return Status.DISABLED
         }
 
         return Status.UP_TO_DATE


### PR DESCRIPTION
Before "grapheneos.package_update_preserves_package_enabled_setting" system feature, update of disabled package made it re-enabled.

Android 14 should add an API for this, but it hasn't stabilized yet.

Closes https://github.com/GrapheneOS/Apps/issues/266