### PR TITLE
bugfix(startPackageUpdate): store non-self packages to be updated in …

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/core/InstallStart.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/InstallStart.kt
@@ -307,6 +307,7 @@ fun startPackageUpdate(params: InstallParams, rPackageGroups: List<List<RPackage
     check(params.isUpdate)
 
     var selfUpdateGroup: List<RPackage>? = null
+    val otherUpdateGroups = mutableListOf<List<RPackage>>()
 
     for (rPackageGroup in rPackageGroups) {
         val selfPkgCount = rPackageGroup.count { it.packageName == selfPkgName }
@@ -314,6 +315,8 @@ fun startPackageUpdate(params: InstallParams, rPackageGroups: List<List<RPackage
         if (selfPkgCount == 1) {
             check(selfUpdateGroup == null)
             selfUpdateGroup = rPackageGroup
+        } else {
+            otherUpdateGroups.add(rPackageGroup)
         }
     }
 
@@ -324,7 +327,7 @@ fun startPackageUpdate(params: InstallParams, rPackageGroups: List<List<RPackage
         return listOf(job)
     }
 
-    val jobs = rPackageGroups.map { packages ->
+    val jobs = otherUpdateGroups.map { packages ->
         startInstallTaskInner(packages, params)
     }
 


### PR DESCRIPTION
```
…new list

Fixes a bug where user initiated app updates (for example, through
UpdatesScreen) of self causes crash, because it tries to create two
install tasks for self and crashes (as there can only be a single
install task for a package, creating another causes
IllegalStateException). It creates two install task for self because of
self package being in both rPackageGroups and selfUpdateGroup list. This
bug doesn't affect self update through details screen.
```