### PR TITLE
Accessibility improvements

### DIFF
--- a/app/src/main/res/layout/package_list_item.xml
+++ b/app/src/main/res/layout/package_list_item.xml
@@ -49,6 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:layout_marginEnd="4dp"
+            android:checkable="false"
             android:clickable="false"
             android:contextClickable="false"
             android:longClickable="false"

--- a/app/src/main/res/layout/package_list_item.xml
+++ b/app/src/main/res/layout/package_list_item.xml
@@ -21,7 +21,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            android:contentDescription="@string/app_icon"
+            android:contentDescription="@null"
             tools:src="@drawable/ic_placeholder_app_icon" />
 
         <com.google.android.material.textview.MaterialTextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,8 +72,6 @@
 
     <string name="notif_download_in_progress">Downloading files, %1$s left</string>
 
-    <string name="app_icon">App icon</string>
-
     <string name="notif_title_pending_user_action">Action required</string>
     <string name="notif_text_pending_user_action_install">Confirm installation of %1$s, version %2$s</string>
     <string name="notif_text_pending_user_action_update">Confirm update of %1$s to version %2$s</string>


### PR DESCRIPTION
* remove label of app icon as it's not nessesary and slows down navigation by TalkBack hearing it repetitively on each item.
* Workarround: mark `com.google.android.material.chip.Chip` as uncheckable.
	
	Note that according to Material Design documentation, chip is wrongly applied here:
	
	> Chips are compact elements that represent an input, attribute, or action.
	
	Here it's impossible to do input or action, because in order to change the current channel we do it by other way/screen.
