### PR TITLE
fix static deps for package variants

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/core/Repo.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/Repo.kt
@@ -218,7 +218,7 @@ class RPackageContainer(val repo: Repo, val packageName: String,
                 }
             }
 
-            if (!checkStaticDeps(json, repo)) {
+            if (!checkStaticDeps(jo, repo)) {
                 continue
             }
 


### PR DESCRIPTION
`json` variable references the RPackageContainer object, not RPackage object.