### PR TITLE
Fix search bar chips padding

### DIFF
--- a/app/src/main/res/layout/search_screen.xml
+++ b/app/src/main/res/layout/search_screen.xml
@@ -13,8 +13,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginHorizontal="@dimen/search_bar_horizontal_padding"
         android:hint="@string/search"
         app:endIconMode="clear_text">
 
@@ -39,13 +38,14 @@
         android:orientation="horizontal"
         android:scrollbars="none"
         app:layout_constraintTop_toBottomOf="@id/search_input_layout"
-        app:layout_constraintStart_toStartOf="@id/search_input_layout"
-        app:layout_constraintEnd_toEndOf="@id/search_input_layout">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <com.google.android.material.chip.ChipGroup
             android:id="@+id/pkg_source_filters"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingHorizontal="@dimen/search_bar_horizontal_padding"
             app:singleLine="true">
 
             <com.google.android.material.chip.Chip

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="search_bar_horizontal_padding">16dp</dimen>
+</resources>


### PR DESCRIPTION
Applies the same padding to the search bar and the ChipGroup so that the chips don't get cut off by 16dp on either side

Before
![image](https://github.com/GrapheneOS/Apps/assets/14132249/56af3bdb-66ee-4afa-80f8-5639f5a9e6e6)

After
![image](https://github.com/GrapheneOS/Apps/assets/14132249/43eb6af7-4f4c-4bed-b815-717ed386cb34)
