### PR TITLE
Fix crash on startup on Android 12.

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/ApplicationImpl.kt
+++ b/app/src/main/java/app/grapheneos/apps/ApplicationImpl.kt
@@ -38,7 +38,10 @@ class ApplicationImpl : Application(), ActivityLifecycleCallbacks {
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
         baseAppContext = base
+    }
 
+    override fun onCreate() {
+        super.onCreate()
         PackageStates.requestRepoUpdateNoSuspend()
         PackageStates.init()
 


### PR DESCRIPTION
ItWasntMeWhoFarted on discord reported a crash on startup on a Pixel 3 https://pastebin.com/raw/6F79yg9u [message link](https://discord.com/channels/1176414688112820234/1176434723430608916/1412893081707221163)

My analysis from discord:
It's likely caused by the [compat registerReceiver](https://github.com/GrapheneOS/AppStore/blob/8ec83af5ff33444973096e1b60f7fe79e2a44512/app/src/main/java/app/grapheneos/apps/core/PackageStates.kt#L128) calling [getApplicationContext](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/content/ContextCompat.java;drc=2b5d7088b8ca441777eede6864a9ef741690d94c;l=814) (only on Android 12 or lower), which is [initialized only after Application's attachBaseContext has finished](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/app/LoadedApk.java;drc=50f34b45baed2ec3a256f1c65df4865d72452768;l=1490)
There was a change in january which made the compat registerReceiver always use getApplicationContext, which likely caused this regression during an AppCompat update https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/content/ContextCompat.java;l=649;bpv=1;bpt=0;drc=c283d06f837a2b93b8123d07b7ad5611ba36d9d4;dlc=5c86afb33905d66b89a29ce66362859bc48651e5

Moving the [PackageStates.init()](https://github.com/GrapheneOS/AppStore/blob/8ec83af5ff33444973096e1b60f7fe79e2a44512/app/src/main/java/app/grapheneos/apps/ApplicationImpl.kt#L43) call out of `attachBaseContext` and to `onCreate` fixes this, although the [comment](https://github.com/GrapheneOS/AppStore/blob/8ec83af5ff33444973096e1b60f7fe79e2a44512/app/src/main/java/app/grapheneos/apps/ApplicationImpl.kt#L37) raises a concern that the `RpcProvider` may run before Applications's `onCreate` has finished, but in my testing the calls to the provider only come through after `onCreate`. Are there other reasons why this code was run in `attachBaseContext`?
