### PR TITLE
Fix details screen shared axis transition grouping

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/ui/ViewBindingFragment.kt
+++ b/app/src/main/java/app/grapheneos/apps/ui/ViewBindingFragment.kt
@@ -71,7 +71,6 @@ abstract class ViewBindingFragment<T : ViewBinding> : Fragment(), MenuProvider {
 fun setupSlideTransitions(fragment: Fragment) {
     fragment.apply {
         val axis = MaterialSharedAxis.Y
-//        val axis = MaterialSharedAxis.X
         enterTransition = MaterialSharedAxis(axis, true)
         exitTransition = MaterialSharedAxis(axis, true)
         reenterTransition = MaterialSharedAxis(axis, false)

--- a/app/src/main/res/layout/details_screen.xml
+++ b/app/src/main/res/layout/details_screen.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/details_screen_inner_layout"
+    android:transitionGroup="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clipToPadding="false">


### PR DESCRIPTION
The MaterialSharedAxis transition is being applied to individual children of the detail screen's ScrollView, causing an unintended clipping effect on each item when animating in (most noticeable if you watch the "Install" button). Adding `transitionGroup=true` fixes this and animates the ScrollView as a single container.

https://github.com/user-attachments/assets/00cbb8cc-dc4c-4ac3-a787-dbe060099ea6

https://github.com/user-attachments/assets/49411997-b422-4315-b8f1-c0fad7e64e93

