### PR TITLE
Two bug fixes for per-app locale support

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/core/PackageStates.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/PackageStates.kt
@@ -122,12 +122,14 @@ object PackageStates : LifecycleEventObserver {
             addAction(Intent.ACTION_PACKAGE_CHANGED)
             addAction(Intent.ACTION_PACKAGE_REPLACED)
             addAction(Intent.ACTION_PACKAGE_REMOVED)
-
-            if (Build.VERSION.SDK_INT >= 33) {
-                addAction(Intent.ACTION_APPLICATION_LOCALE_CHANGED)
-            }
         }
         appContext.registerReceiver(receiver, filter)
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            // ACTION_APPLICATION_LOCALE_CHANGED has no package: data URI, so it needs a separate IntentFilter without addDataScheme("package").
+            val localeFilter = IntentFilter(Intent.ACTION_APPLICATION_LOCALE_CHANGED)
+            appContext.registerReceiver(receiver, localeFilter)
+        }
     }
 
     fun updateRepo(repo: Repo) {

--- a/app/src/main/java/app/grapheneos/apps/core/Repo.kt
+++ b/app/src/main/java/app/grapheneos/apps/core/Repo.kt
@@ -454,7 +454,7 @@ class RPackage(val common: RPackageContainer, val versionCode: Long, val abis: A
                 list
             }
 
-            if (!pkgSpecificLocales.isEmpty) {
+            if (pkgSpecificLocales.isEmpty) {
                 return globalLocales
             }
 


### PR DESCRIPTION
**Repo: fix inverted isEmpty check for per-app locale split selection**

The merge of per-app locales into the global locale set was guarded by `!pkgSpecificLocales.isEmpty`, so it only ran when the list was empty. Per-app language preferences had no effect on language split APK selection.

**PackageStates: register locale-change receiver without package data scheme**

`ACTION_APPLICATION_LOCALE_CHANGED` carries no `package:` data URI. Registering it in an `IntentFilter` with `addDataScheme("package")` caused Android to drop the broadcast, so `pkgSpecificLocales` was never refreshed when the user changed per-app language settings.